### PR TITLE
fix add document from admin panel error

### DIFF
--- a/src/main/java/com/himanshudabas/springboot/travelticketing/service/TicketServiceImpl.java
+++ b/src/main/java/com/himanshudabas/springboot/travelticketing/service/TicketServiceImpl.java
@@ -120,6 +120,7 @@ public class TicketServiceImpl implements TicketService {
     }
 
     @Override
+    @Transactional
     public TicketResolveInfoDto changeTicketResolveInfo(Long ticketId, CustomResolveInfoDto request) throws Exception {
         Optional<Ticket> ticket = ticketRepository.findById(ticketId);
         ResolveInfo resolveInfo = ticketResolveInfoRepository.getOne(ticketId);
@@ -135,6 +136,7 @@ public class TicketServiceImpl implements TicketService {
             // if document is uploaded then save it
             Document newDoc = getNewDocument(request.getDocuments(), resolveInfo);
             documentRepository.save(newDoc);
+            resolveInfo.getDocuments().add(newDoc);
             changed = true;
         }
         if (!request.getComment().equals(resolveInfo.getComment())) {


### PR DESCRIPTION
There was a bug which would not allow the admin to add files due to documents being loaded into the `ResolveInfo` model lazily.

To fix the bug @Transactional annotation is added to the method performing the said task. which allows to fetch the documents into the `ResolveInfo` model and append new documents to the list of documents.